### PR TITLE
Support for Accept-Language header in Fastly VCL

### DIFF
--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -59,20 +59,20 @@ sub vcl_recv {
     # thing, reducing cache misses due to ordering differences.
     set req.url = boltsort.sort(req.url);
 
-    # Strip Accept-Language headers from request, the backends currently attempt
-    # to respect this, but we're not setup for it yet... in VCL or otherwise.
-    # This leads to us caching translated content in the default locale (en).
-    unset req.http.Accept-Language;
-
     # Synthesize a custom header for the locale if set, so we can vary on this
     # instead of the entire cookie, only do this on the edge. Shields should
     # ignore cookies.
     if (!req.http.Fastly-FF) {
-        # Default to english for cached content
-        set req.http.PyPI-Locale = "en";
-
         if (req.http.Cookie:_LOCALE_ && req.http.Cookie:_LOCALE_ != "") {
+            # Cookie language always wins
             set req.http.PyPI-Locale = req.http.Cookie:_LOCALE_;
+        } else {
+            # Lookup in Accept-Language header
+            set req.http.PyPI-Locale = accept.language_lookup("en:es:fr:ja:pt-BR:uk:el:de", "en", req.http.Accept-Language);
+            if (!req.http.PyPI-Locale) {
+                # Fallback to english if no other language matches
+                set req.http.PyPI-Locale = "en";
+            }
         }
     }
 

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -64,13 +64,13 @@ sub vcl_recv {
     # ignore cookies.
     if (!req.http.Fastly-FF) {
         if (req.http.Cookie:_LOCALE_ && req.http.Cookie:_LOCALE_ != "") {
-            # Cookie language always wins
+            # If set, language from cookie always wins
             set req.http.PyPI-Locale = req.http.Cookie:_LOCALE_;
         } else {
-            # Lookup in Accept-Language header
+            # Lookup in Accept-Language header, fallback to "en" if no match found in supported languages
             set req.http.PyPI-Locale = accept.language_lookup("en:es:fr:ja:pt-BR:uk:el:de", "en", req.http.Accept-Language);
             if (!req.http.PyPI-Locale) {
-                # Fallback to english if no other language matches
+                # Safety-check: If PyPI-Locale is empty, default to "en"
                 set req.http.PyPI-Locale = "en";
             }
         }


### PR DESCRIPTION
This adds support for using the Accept-Language header to Fastly config for the currently known locales.
Unfortunately needs to be edited every time locales change.