### PR TITLE
add Lets Encrypt to CAA

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,6 +41,7 @@ module "dns" {
   caa_issuers = [
     "amazon.com",
     "globalsign.com",
+    "letsencrypt.org",
   ]
 
   apex_txt = [


### PR DESCRIPTION
Fastly will be issuing upcoming renewals with Lets Encrypt, add them as a CAA issuer