### PR TITLE
disable DMARC reporting to postmaster@pypi.org

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -70,7 +70,7 @@ module "email" {
   display_name = "PyPI"
   zone_id      = module.dns.primary_zone_id
   domain       = "pypi.org"
-  dmarc        = "mailto:re+wln41pimbs0@dmarc.postmarkapp.com,postmaster@pypi.org"
+  dmarc        = "mailto:re+wln41pimbs0@dmarc.postmarkapp.com"
   hook_url     = "https://pypi.org/_/ses-hook/"
 }
 
@@ -82,7 +82,7 @@ module "testpypi-email" {
   display_name = "TestPyPI"
   zone_id      = module.dns.primary_zone_id
   domain       = "test.pypi.org"
-  dmarc        = "mailto:re+a1s3u37pyvs@dmarc.postmarkapp.com,postmaster@pypi.org"
+  dmarc        = "mailto:re+a1s3u37pyvs@dmarc.postmarkapp.com"
   hook_url     = "https://test.pypi.org/_/ses-hook/"
 }
 


### PR DESCRIPTION
This has been noisy and hasn't provided sufficient insight to determine what is going on with our DKIM alignment