### PR TITLE
normalize Accept-Language header in vcl_recv

### DIFF
--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -148,7 +148,8 @@ sub vcl_recv {
             # This list should mirror the KNOWN_LOCALES identifier list in https://github.com/pypi/warehouse/blob/main/warehouse/i18n/__init__.py
             # Note that the format for tags may be different than those in KNOWN_LOCALES
             # reference https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry for correct values.
-            set req.http.PyPI-Locale = accept.language_lookup("en:es:fr:ja:pt-BR:uk:el:de:zh-Hans:zh-Hant:ru:he:eo", "en", req.http.Accept-Language);
+            set req.http.Accept-Language = accept.language_lookup("en:es:fr:ja:pt-BR:uk:el:de:zh-Hans:zh-Hant:ru:he:eo", "en", req.http.Accept-Language);
+            set req.http.PyPI-Locale = req.http.Accept-Language;
 
             if (!req.http.PyPI-Locale) {
                 # Safety-check: If PyPI-Locale is empty, default to "en"


### PR DESCRIPTION
This ensures only a single value of Accept-Language makes it to our backends, and that it matches PyPI-Locale

Follows on from #109, attempts to resolve https://github.com/pypi/warehouse/issues/12445