### PR TITLE
allow Fastly/cache-check to bypass SNI disable in VCL

### DIFF
--- a/terraform/file-hosting/fastly-service.tf
+++ b/terraform/file-hosting/fastly-service.tf
@@ -1,7 +1,7 @@
 resource "fastly_service_vcl" "files" {
   name     = var.fastly_service_name
   # Set to false for spicy changes
-  activate = false
+  activate = true
 
   domain {
     name = var.domain

--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -56,8 +56,8 @@ sub vcl_recv {
         error 603 "SSL is required";
     }
 
-    # Forbid clients without SNI support (Note this is disabled at Fastly's level, but provide a fallback).
-    if (!req.http.Fastly-FF && tls.client.servername == "") {
+    # Forbid clients without SNI support, except Fastly/cache-check (Note this is disabled at edge, but provide a fallback).
+    if (!req.http.Fastly-FF && tls.client.servername == "" && req.http.User-Agent != "Fastly/cache-check") {
         error 604 "SNI is required";
     }
 

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -198,8 +198,8 @@ sub vcl_recv {
         }
     }
 
-    # Forbid clients without SNI support (Note this is disabled at Fastly's level, but provide a fallback).
-    if (!req.http.Fastly-FF && tls.client.servername == "") {
+    # Forbid clients without SNI support, except Fastly/cache-check (Note this is disabled at edge, but provide a fallback).
+    if (!req.http.Fastly-FF && tls.client.servername == "" && req.http.User-Agent != "Fastly/cache-check") {
         error 604 "SNI is required";
     }
 


### PR DESCRIPTION
We were hitting this when using the Fastly Cache Check API. Bypass VCL SNI check when User-Agent is Fastly/cache-check.

This VCL shouldn't be accessible to people accessing PyPI using Non-SNI clients, as those should be getting the wrong cert at the edge anyway.