### PR TITLE
enable fastly streaming miss for package urls

### DIFF
--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -116,6 +116,11 @@ sub vcl_fetch {
         set beresp.cacheable = true;
     }
 
+    # Enable Streaming miss for package URLS
+    if (req.url ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/") {
+        set beresp.do_stream = true;
+    }
+
     # If we successfully got a 404 response from GCS for a Package URL restart
     # to check S3 for the file!
     if (req.restarts == 0 && req.backend == GCS && req.url ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/" && http_status_matches(beresp.status, "404")) {


### PR DESCRIPTION
Not sure if we actually want this, given the caveat:

> If you enable Streaming Miss, be aware that [if an error occurs](https://docs.fastly.com/en/guides/failure-modes-with-large-objects) while transferring the response body, Fastly cannot send an error because the headers are already sent to the client. All we can do is truncate the response.

https://docs.fastly.com/en/guides/streaming-miss