### PR TITLE
Use Fastly to do Compression

### DIFF
--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -296,6 +296,29 @@ sub vcl_recv {
 }
 
 
+# Common logic for both miss and pass
+sub miss_pass {
+    # Remove Accept-Encoding header to prevent origin server from doing
+    # gzip by itself, since we want to do it at the Edge
+    unset bereq.http.Accept-Encoding;
+}
+
+
+sub vcl_pass {
+#FASTLY pass
+
+  call miss_pass;
+}
+
+
+sub vcl_miss {
+#FASTLY miss
+
+  call miss_pass;
+}
+
+
+
 sub vcl_fetch {
 
     # These are newer kinds of redirects which should be able to be cached by
@@ -340,6 +363,35 @@ sub vcl_fetch {
     # If we've restarted, then we'll record the number of restarts.
     if(req.restarts > 0 ) {
         set beresp.http.Fastly-Restarts = req.restarts;
+    }
+
+    # We want to enable compression, but due to CRIME attacks we want to skip
+    # compressing anything that Varies on a Cookie or Authorization header
+    # because we don't know if they are safe to compress.
+    #
+    # We also want to skip it if we've already gotten a Content-Encoding
+    if (beresp.http.Vary !~ "(?i)(Cookie|Authorization)" &&
+            !beresp.http.Content-Encoding) {
+        # Always set a Vary header, even if we don't end up compressing
+        # the object, because the uncompressed version should only be
+        # used when the request does NOT request the compressed one.
+        if (!beresp.http.Vary ~ "Accept-Encoding") {
+            if (beresp.http.Vary) {
+                set beresp.http.Vary = beresp.http.Vary ", Accept-Encoding";
+            } else {
+                set beresp.http.Vary = "Accept-Encoding";
+            }
+        }
+
+        # Perform compression if the client claims to understand it
+        if (req.http.Accept-Encoding == "gzip") {
+            set beresp.gzip = true;
+        } else if (req.http.Accept-Encoding == "br") {
+            set beresp.brotli = true;
+        } else {
+            set beresp.gzip = false;
+            set beresp.brotli = false;
+        }
     }
 
     # If there is a Set-Cookie header, we'll ensure that we do not cache the


### PR DESCRIPTION
Basically this will use Fastly to handle our compression rather than letting Warehouse do it.

This should reduce the amount of CPU our origin servers expend, but more importantly it means that we can do certain optimizations in Warehouse around conditional ``GET`` requests where we can skip executing the view if we know ahead of time that we can return a ``304 Not Modified``. Currently this is impossible in Warehouse because the compression tween needs to read the response body to handle the ETag on compressed responses.

This should roughly match the behavior of the existing compression tween, with the following differences:

- The existing tween only supports gzip, this supports gzip and brotli.
- The existing tween has some logic in it to skip compressing if the compressed result is larger than the uncompressed result, where I can't find any information what Fastly would do in this case.
- The ETags derived by the tween are likely going to be different then the ETags derived by Fastly.

This should work without code changes in Warehouse, because in `vcl_miss` and `vcl_pass` we modify the request that is going to be sent to the origin to remove the ``Accept-Encoding`` header, so Warehouse will only see requests that accept uncompressed content.