### PR TITLE
Add seasoning

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -30,6 +30,10 @@ variable "warehouse_token" {
   type      = string
   sensitive = true
 }
+variable "warehouse_ip_salt" {
+  type      = string
+  sensitive = true
+}
 variable "test_pypi_warehouse_token" {
   type      = string
   sensitive = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -99,7 +99,8 @@ module "pypi" {
   mirror          = "mirror.dub1.pypi.io"
   s3_logging_keys = var.fastly_s3_logging
 
-  warehouse_token = var.warehouse_token
+  warehouse_token   = var.warehouse_token
+  warehouse_ip_salt = var.warehouse_ip_salt
 
   linehaul_enabled = true
   linehaul_gcs = {
@@ -124,7 +125,8 @@ module "test-pypi" {
   mirror          = "test-mirror.dub1.pypi.io"
   s3_logging_keys = var.fastly_s3_logging
   
-  warehouse_token = var.test_pypi_warehouse_token
+  warehouse_token   = var.test_pypi_warehouse_token
+  warehouse_ip_salt = var.warehouse_ip_salt
 
   linehaul_enabled = false
   linehaul_gcs     = {

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -8,6 +8,7 @@ variable "s3_logging_keys" { type = map(any) }
 variable "linehaul_enabled" { type = bool }
 variable "linehaul_gcs" { type = map(any) }
 variable "warehouse_token" { type = string }
+variable "warehouse_ip_salt" { type = string }
 
 variable "fastly_endpoints" { type = map(any) }
 variable "domain_map" { type = map(any) }
@@ -37,6 +38,13 @@ resource "fastly_service_vcl" "pypi" {
   snippet {
     content  = "set req.http.Warehouse-Token = \"${var.warehouse_token}\";"
     name     = "Warehouse Token"
+    priority = 100
+    type     = "recv"
+  }
+
+  snippet {
+    content  = "set var.Warehouse-Ip-Salt = \"${var.warehouse_ip_salt}\";"
+    name     = "Warehouse IP Salt"
     priority = 100
     type     = "recv"
   }

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -274,11 +274,15 @@ sub vcl_recv {
 
         # Geolocate the client IP address.
         # Set distinct headers for country, region, and city.
-        if (client.geo.country_code != "**") {
-            set req.http.Warehouse-Country = client.geo.country_name;
-            set req.http.Warehouse-Region = client.geo.region;
-            set req.http.Warehouse-City = client.geo.city;
-        }
+        # See https://developer.fastly.com/reference/vcl/variables/geolocation/
+        # Any placeholder values for reserved blocks are sent through
+        # and left to pypi/warehouse on how to process
+        set req.http.Warehouse-Continent = client.geo.continent_code;
+        set req.http.Warehouse-Country-Code = client.geo.country_code;
+        set req.http.Warehouse-Country-Code-3 = client.geo.country_code3;
+        set req.http.Warehouse-Country = client.geo.country_name;
+        set req.http.Warehouse-Region = client.geo.region;
+        set req.http.Warehouse-City = client.geo.city;
     }
     # Pass the real host value back to the backend.
     if (req.http.Host) {

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -272,20 +272,13 @@ sub vcl_recv {
         # TODO: After backend is updated, replace or remove `req.http.Warehouse-IP` above
         set req.http.Warehouse-Hashed-IP = var.hashed_ip;
 
-        # Geolocate the client IP address. We want details like city, state, country, etc.
-        declare local var.geo STRING;
+        # Geolocate the client IP address.
+        # Set distinct headers for country, region, and city.
         if (client.geo.country_code != "**") {
-            set var.geo = client.geo.country_name;
-            if (client.geo.region != "NO REGION" && client.geo.region != "?") {
-            set var.geo = var.geo + "-" + client.geo.region;
-            }
-            # add city if it's not the same as the region
-            if (client.geo.city != "NO CITY" && client.geo.city != "?"
-                && client.geo.city != client.geo.region) {
-            set var.geo = var.geo + "-" + client.geo.city;
-            }
+            set req.http.Warehouse-Country = client.geo.country_name;
+            set req.http.Warehouse-Region = client.geo.region;
+            set req.http.Warehouse-City = client.geo.city;
         }
-        set req.http.Warehouse-Geo = var.geo;
     }
     # Pass the real host value back to the backend.
     if (req.http.Host) {

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -271,6 +271,21 @@ sub vcl_recv {
         set var.hashed_ip = digest.hash_sha256(var.client_ip);
         # TODO: After backend is updated, replace or remove `req.http.Warehouse-IP` above
         set req.http.Warehouse-Hashed-IP = var.hashed_ip;
+
+        # Geolocate the client IP address. We want details like city, state, country, etc.
+        declare local var.geo STRING;
+        if (client.geo.country_code != "**") {
+            set var.geo = client.geo.country_name;
+            if (client.geo.region != "NO REGION" && client.geo.region != "?") {
+            set var.geo = var.geo + "-" + client.geo.region;
+            }
+            # add city if it's not the same as the region
+            if (client.geo.city != "NO CITY" && client.geo.city != "?"
+                && client.geo.city != client.geo.region) {
+            set var.geo = var.geo + "-" + client.geo.city;
+            }
+        }
+        set req.http.Warehouse-Geo = var.geo;
     }
     # Pass the real host value back to the backend.
     if (req.http.Host) {


### PR DESCRIPTION
Makes some new headers tasty.

- Adds salted hash (browns) to the client IP address. Does not impact existing behaviors, but starts to send the details to the backend
- Adds geo value header based on country name + region and/or city

Needs some extra 👀  and validation - I'm not certain how this gets rolled out to test before prod