### PR TITLE
Do not enable segmented caching for .metadata files

### DIFF
--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -5,6 +5,10 @@ sub vcl_recv {
     # Enable Segmented Caching for package URLS
     if (req.url ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/") {
         set req.enable_segmented_caching = true;
+        if (req.url ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/(.*).metadata$") {
+            # Don't enable segmented caching if we're serving a metadata file
+            set req.enable_segmented_caching = false;
+        }
     }
 
     # I'm not 100% sure on what this is exactly for, it was taken from the


### PR DESCRIPTION
Fastly can't do compression for us if we have segmented caching enabled.