### PR TITLE
ease off on b2 timeouts

### DIFF
--- a/terraform/file-hosting/fastly-service.tf
+++ b/terraform/file-hosting/fastly-service.tf
@@ -69,7 +69,7 @@ resource "fastly_service_vcl" "files" {
     ssl_sni_hostname = "${var.files_bucket}.s3.us-east-005.backblazeb2.com"
 
     connect_timeout       = 2000
-    first_byte_timeout    = 200
+    first_byte_timeout    = 2000
     between_bytes_timeout = 3000
     error_threshold       = 5
   }

--- a/terraform/file-hosting/fastly-service.tf
+++ b/terraform/file-hosting/fastly-service.tf
@@ -68,9 +68,9 @@ resource "fastly_service_vcl" "files" {
     ssl_cert_hostname = "${var.files_bucket}.s3.us-east-005.backblazeb2.com"
     ssl_sni_hostname = "${var.files_bucket}.s3.us-east-005.backblazeb2.com"
 
-    connect_timeout       = 1000
-    first_byte_timeout    = 1500
-    between_bytes_timeout = 2000
+    connect_timeout       = 2000
+    first_byte_timeout    = 200
+    between_bytes_timeout = 3000
     error_threshold       = 5
   }
 


### PR DESCRIPTION
occasionally b2 responses lead to fallbacks to s3 that makes a line jump that catches the eyes of a pypi admin that leads to us looking and finding nothing actionable.

up the timeouts a bit to reduce these redherrings a bit?