### PR TITLE
chore: add Permissions-Policy header to warehouse

### DIFF
--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -21,7 +21,7 @@ locals {
 resource "fastly_service_vcl" "pypi" {
   name     = var.name
   # Set to false for spicy changes
-  activate = true
+  activate = false
 
   domain { name = var.domain }
 

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -478,41 +478,7 @@ sub vcl_deliver {
     set resp.http.X-Permitted-Cross-Domain-Policies = "none";
 
     # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy
-    set resp.http.Permissions-Policy = {"
-        publickey-credentials-create=(self),
-        publickey-credentials-get=(self),
-        accelerometer=(),
-        ambient-light-sensor=(),
-        autoplay=(),
-        battery=(),
-        camera=(),
-        display-capture=(),
-        document-domain=(),
-        encrypted-media=(),
-        execution-while-not-rendered=(),
-        execution-while-out-of-viewport=(),
-        fullscreen=(),
-        gamepad=(),
-        geolocation=(),
-        gyroscope=(),
-        hid=(),
-        identity-credentials-get=(),
-        idle-detection=(),
-        local-fonts=(),
-        magnetometer=(),
-        microphone=(),
-        midi=(),
-        otp-credentials=(),
-        payment=(),
-        picture-in-picture=(),
-        screen-wake-lock=(),
-        serial=(),
-        speaker-selection=(),
-        storage-access=(),
-        usb=(),
-        web-share=(),
-        xr-spatial-tracking=()
-    ";}
+    set resp.http.Permissions-Policy = {"publickey-credentials-create=(self),publickey-credentials-get=(self),accelerometer=(),ambient-light-sensor=(),autoplay=(),battery=(),camera=(),display-capture=(),document-domain=(),encrypted-media=(),execution-while-not-rendered=(),execution-while-out-of-viewport=(),fullscreen=(),gamepad=(),geolocation=(),gyroscope=(),hid=(),identity-credentials-get=(),idle-detection=(),local-fonts=(),magnetometer=(),microphone=(),midi=(),otp-credentials=(),payment=(),picture-in-picture=(),screen-wake-lock=(),serial=(),speaker-selection=(),storage-access=(),usb=(),web-share=(),xr-spatial-tracking=()";}
 
     return(deliver);
 }

--- a/terraform/warehouse/vcl/main.vcl
+++ b/terraform/warehouse/vcl/main.vcl
@@ -477,6 +477,43 @@ sub vcl_deliver {
     set resp.http.X-Content-Type-Options = "nosniff";
     set resp.http.X-Permitted-Cross-Domain-Policies = "none";
 
+    # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy
+    set resp.http.Permissions-Policy = {"
+        publickey-credentials-create=(self),
+        publickey-credentials-get=(self),
+        accelerometer=(),
+        ambient-light-sensor=(),
+        autoplay=(),
+        battery=(),
+        camera=(),
+        display-capture=(),
+        document-domain=(),
+        encrypted-media=(),
+        execution-while-not-rendered=(),
+        execution-while-out-of-viewport=(),
+        fullscreen=(),
+        gamepad=(),
+        geolocation=(),
+        gyroscope=(),
+        hid=(),
+        identity-credentials-get=(),
+        idle-detection=(),
+        local-fonts=(),
+        magnetometer=(),
+        microphone=(),
+        midi=(),
+        otp-credentials=(),
+        payment=(),
+        picture-in-picture=(),
+        screen-wake-lock=(),
+        serial=(),
+        speaker-selection=(),
+        storage-access=(),
+        usb=(),
+        web-share=(),
+        xr-spatial-tracking=()
+    ";}
+
     return(deliver);
 }
 


### PR DESCRIPTION
When performing responses to users, set the Permissions-Policy header to inform the browser that the only functions we actually care about are related to WebAuthN, and nothing else.

Refs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Permissions_Policy
Refs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy