### PR TITLE
feat: add ngwaf to pypi instances

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,80 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/backblaze/b2" {
+  version = "0.8.12"
+  hashes = [
+    "h1:DKZehZTdHC0fJzAA74yMzUaHm1PisNaNaBQjAOSS9kk=",
+    "zh:bc9d25d21adeafba8edde8d6ffb6150cd5c86c207412c8941347966be3363de5",
+    "zh:c538eaea1b15379635b9d8a2cb862248813022bb0de5481741f18fcc77a10a1b",
+    "zh:cc2767797ad27b9a3b4ad97b6a2f3eeea9f50a6000bbcfa9b44189945dae30b3",
+    "zh:d83b5f0e632ea56570a0737c1896f049367201cc67f5de83baa24272ccdd56a4",
+  ]
+}
+
+provider "registry.terraform.io/fastly/fastly" {
+  version     = "5.13.0"
+  constraints = ">= 5.13.0, 5.13.0"
+  hashes = [
+    "h1:op/7hntTRkfZFIZ5xLNtLb7eBY155ywQIVSy56XCmBE=",
+    "zh:04f7405ee22a8ace546b90cc3a08d81f1a49dae8b1050500398d4b0244dcbc86",
+    "zh:0e0c48aca34a1fc7ed7382c8e85b5da770f63f3c9aa79bc2c3c55ed570f9d0ab",
+    "zh:302d2b9872ab8ffee2082291cc2cfec487633e22c7970b2c9d22268d6b5f7624",
+    "zh:346ea021dbe2c7128cddc2c9e01a95242b8bceeda20d9d1b00ae09ee90e3962b",
+    "zh:41fbe18f63154a6a1a46e1b1cc909bfe90f5bba7f5cfab0a80d15be7eceec4c3",
+    "zh:524c2a54282a92d0d7633bfd511427f6d9aa6b6a52b7d9f71cf5206dedab381e",
+    "zh:721fe08bfb1b85f8946aeba3bdb7e0de3d74fce94c8657d0086b153f58558d89",
+    "zh:9c627b3170a5505c73455e6c2a99d2ce4187e225130e12aececdc808357f8b66",
+    "zh:a61a62cec9612358b08ef1895277a37d4d4ec134972991fa414255ef95683dba",
+    "zh:bde1a51553c15d333140c2b77481ee668c4af8de93a968d869c02a736db460c4",
+    "zh:c2683862bd0e9633d3800503a71b3aab51ec8e3aac3f6ef6b71831efe81a2afd",
+    "zh:dff5ad3766432550974d2f0c24535c572fee5eeb0dce7befeaa97cb6ca3d8443",
+    "zh:ec3c56fc43344a07b0eef5158df6dd50e68bdcee1b03299bb2acd502d11582d5",
+    "zh:ec8d899cafd925d3492f00c6523c90599aebc43c1373ad4bd6c55f12d2376230",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.13.0"
+  constraints = "5.13.0"
+  hashes = [
+    "h1:DdmY4NUNU6J+Rls2Tsvs+P56tpZLOz/BMpcikMulTPo=",
+    "zh:272a35cf751dcac35ccd512d5d024c1bee132ed7c9dc1932085127334c9c409a",
+    "zh:31cc60eaa091e3ce07127d76a60bb54021a60d3d923448535178a1de00520c47",
+    "zh:499338f4b42a6e6f7de50fc8e39bef738b39d140f12213de27fa2614f5d351e8",
+    "zh:4a177cf043be3341a0315601d26a380bf2cb38a12911072f8e7f43d2751ed6bb",
+    "zh:5b818349703f1d429fd45d238c23505cd3aa1f255a69036767ca894e87e7e804",
+    "zh:6840d4c536373be4d6fad972026d1862394805275ed7c5831e469f23b5fafc09",
+    "zh:7a113f2b2d5fac0977d2f450c293a636a8fbd8b1d9c901bfd2a769491f279a42",
+    "zh:8581992cbe1dd0d6b7d13542ae2e836cfb8a61751423836116ac12ad7bbe6cd2",
+    "zh:8fabc85d45da58fff3b16a82f8037c7e8f75cb6dd874ff02cb66b4d40f0feb5e",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:e06e561b64a75eb811857bfd5ec213dc29905d613997a5bf9a806f2832c34691",
+    "zh:e3ea285ffec19da66622aab752c45ebea46b1d75bb4f8d775e081f76849290ac",
+    "zh:e855e71782cf3540c16812fda915ae9f830430952c31178b0782da1c12833828",
+    "zh:f5470c5663f4537d6ef387b7e610c9af1c761b4519a1ee9d305946a7b0c2721e",
+    "zh:fb494bfc3f0aaf9dfa47bfbaacc852a08631de08bb3a6060caf32fcfc978cd71",
+  ]
+}
+
+provider "registry.terraform.io/signalsciences/sigsci" {
+  version     = "3.3.0"
+  constraints = "3.3.0"
+  hashes = [
+    "h1:DIoFVzfofY8lQSxFTw9wmQQC28PPMq+5l3xbPNw9gLc=",
+    "zh:07c25e1cca9c13314429a8430c2e999ad94c7d5e2f2a11501ee2608182387e61",
+    "zh:07daf79b672f3e0bec7b48e3ac8dcdeec02af06b10d653bd8158a74236b0746b",
+    "zh:1e24a050c3d3571ec3224c4bb5c82635caf636e707b5993a1cc97c9a1f19fa8f",
+    "zh:24293ae24b3de13bda8512c47967f01814724805396a1bfbfbfc56f5627615cc",
+    "zh:2cc6ba7a38d9854146d1d05f4b7a2f8e18a33c1267b768506cbe37168dad01dc",
+    "zh:42065bfee0cfde04096d6140c65379253359bed49b481a97aff70aa65bf568b3",
+    "zh:6f7f4d96967dfd92f098b57647d396679b70d92548db6d100c4dc8723569d175",
+    "zh:a2e4431f045cef16ed152c0d1f8a377b6468351b775ad1ca7ce3fe74fb874be2",
+    "zh:b0ed1cb03d6f191fe211f10bb59ef8daed6f89e3d99136e7bb5d38f2ac72fa45",
+    "zh:b61ea18442a65d27b97dd1cd43bdd8d0a56c2b4b8db6355480e89f8507c6782a",
+    "zh:c31bb2f50ac2a636758f93afec0b9d173be6d7d7476f9e250b4554e70c6d8d82",
+    "zh:cb7337f7b4678ad7ece28741069c07ce5601d2a103a9667db568cf10ed0ee5a2",
+    "zh:d521a7dac51733aebb0905e25b8f7c1279d83c06136e87826e010c667528fd3e",
+    "zh:ef791688acee3b8b1191b3c6dc54dabf69612dbfb666720280b492ce348a3a06",
+  ]
+}

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -87,8 +87,8 @@ provider "fastly" {
 
 provider "sigsci" {
   alias          = "firewall"
-  corp           = var.ngwaf_corp_name
-  email          = var.ngwaf_email
+  corp           = "python"
+  email          = "infrastructure-staff@python.org"
   auth_token     = var.ngwaf_token
   fastly_api_key = var.credentials["fastly"]
 }

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -47,6 +47,40 @@ variable "x_pypi_admin_token" {
   sensitive = true
 }
 
+## NGWAF
+variable "activate_ngwaf_service" {
+  type        = bool
+  description = "Whether to activate the NGWAF service."
+}
+variable "edge_security_dictionary" {
+  type        = string
+  description = "The dictionary name for the Edge Security product."
+  default     = "Edge_Security"
+}
+variable "ngwaf_corp_name" {
+  type        = string
+  description = "Corp name for NGWAF"
+  default     = "python"
+}
+variable "ngwaf_site_name" {
+  type        = string
+  description = "Site SHORT name for NGWAF"
+
+  validation {
+    condition     = can(regex("^(pypi-test|pypi-prod)$", var.ngwaf_site_name))
+    error_message = "'ngwaf_site_name' must be one of the following: pypi-test, or pypiprod"
+  }
+}
+variable "ngwaf_email" {
+  type        = string
+  description = "Email address associated with the token for the NGWAF API."
+}
+variable "ngwaf_token" {
+  type        = string
+  description = "Secret token for the NGWAF API."
+  sensitive   = true
+}
+
 terraform {
   cloud {
     organization = "psf"
@@ -76,4 +110,12 @@ provider "aws" {
 
 provider "fastly" {
   api_key = var.credentials["fastly"]
+}
+
+provider "sigsci" {
+  alias          = "firewall"
+  corp           = var.ngwaf_corp_name
+  email          = var.ngwaf_email
+  auth_token     = var.ngwaf_token
+  fastly_api_key = var.credentials["fastly"]
 }

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -48,33 +48,6 @@ variable "x_pypi_admin_token" {
 }
 
 ## NGWAF
-variable "activate_ngwaf_service" {
-  type        = bool
-  description = "Whether to activate the NGWAF service."
-}
-variable "edge_security_dictionary" {
-  type        = string
-  description = "The dictionary name for the Edge Security product."
-  default     = "Edge_Security"
-}
-variable "ngwaf_corp_name" {
-  type        = string
-  description = "Corp name for NGWAF"
-  default     = "python"
-}
-variable "ngwaf_site_name" {
-  type        = string
-  description = "Site SHORT name for NGWAF"
-
-  validation {
-    condition     = can(regex("^(pypi-test|pypi-prod)$", var.ngwaf_site_name))
-    error_message = "'ngwaf_site_name' must be one of the following: pypi-test, or pypiprod"
-  }
-}
-variable "ngwaf_email" {
-  type        = string
-  description = "Email address associated with the token for the NGWAF API."
-}
 variable "ngwaf_token" {
   type        = string
   description = "Secret token for the NGWAF API."

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -53,6 +53,11 @@ variable "ngwaf_token" {
   description = "Secret token for the NGWAF API."
   sensitive   = true
 }
+variable "ngwaf_email" {
+  type        = string
+  description = "Email address for the NGWAF API."
+  default     = "infrastructure-staff@python.org"
+}
 
 terraform {
   cloud {
@@ -88,7 +93,7 @@ provider "fastly" {
 provider "sigsci" {
   alias          = "firewall"
   corp           = "python"
-  email          = "infrastructure-staff@python.org"
+  email          = var.ngwaf_email
   auth_token     = var.ngwaf_token
   fastly_api_key = var.credentials["fastly"]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -111,10 +111,10 @@ module "pypi" {
   domain_map       = local.domain_map
 
   # NGWAF
-  ngwaf_site_name        = "pypi-prod"
-  ngwaf_email            = "infrastructure-staff@python.org"
-  ngwaf_token            = var.ngwaf_token
-  activate_ngwaf_service = false
+  ngwaf_site_name          = "pypi-prod"
+  ngwaf_email              = "infrastructure-staff@python.org"
+  ngwaf_token              = var.ngwaf_token
+  activate_ngwaf_service   = false
   edge_security_dictionary = "Edge_Security"
 }
 
@@ -145,10 +145,10 @@ module "test-pypi" {
   domain_map       = local.domain_map
 
   # NGWAF
-  ngwaf_site_name        = "pypi-test"
-  ngwaf_email            = "infrastructure-staff@python.org"
-  ngwaf_token            = var.ngwaf_token
-  activate_ngwaf_service = true
+  ngwaf_site_name          = "pypi-test"
+  ngwaf_email              = "infrastructure-staff@python.org"
+  ngwaf_token              = var.ngwaf_token
+  activate_ngwaf_service   = true
   edge_security_dictionary = "Edge_Security"
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -109,6 +109,13 @@ module "pypi" {
 
   fastly_endpoints = local.fastly_endpoints
   domain_map       = local.domain_map
+
+  # NGWAF
+  ngwaf_site_name        = "pypi-prod"
+  ngwaf_email            = "infrastructure-staff@python.org"
+  ngwaf_token            = var.ngwaf_token
+  activate_ngwaf_service = false
+  edge_security_dictionary = "Edge_Security"
 }
 
 module "test-pypi" {
@@ -136,6 +143,13 @@ module "test-pypi" {
 
   fastly_endpoints = local.fastly_endpoints
   domain_map       = local.domain_map
+
+  # NGWAF
+  ngwaf_site_name        = "pypi-test"
+  ngwaf_email            = "infrastructure-staff@python.org"
+  ngwaf_token            = var.ngwaf_token
+  activate_ngwaf_service = true
+  edge_security_dictionary = "Edge_Security"
 }
 
 module "file-hosting" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -112,7 +112,7 @@ module "pypi" {
 
   # NGWAF
   ngwaf_site_name          = "pypi-prod"
-  ngwaf_email              = "infrastructure-staff@python.org"
+  ngwaf_email              = var.ngwaf_email
   ngwaf_token              = var.ngwaf_token
   activate_ngwaf_service   = false
   edge_security_dictionary = "Edge_Security"
@@ -146,7 +146,7 @@ module "test-pypi" {
 
   # NGWAF
   ngwaf_site_name          = "pypi-test"
-  ngwaf_email              = "infrastructure-staff@python.org"
+  ngwaf_email              = var.ngwaf_email
   ngwaf_token              = var.ngwaf_token
   activate_ngwaf_service   = true
   edge_security_dictionary = "Edge_Security"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     fastly = {
       source  = "fastly/fastly"
-      version = "1.1.2"
+      version = "5.13.0"
     }
     sigsci = {
       source  = "signalsciences/sigsci"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "fastly/fastly"
       version = "1.1.2"
     }
+    sigsci = {
+      source  = "signalsciences/sigsci"
+      version = "3.3.0"
+    }
   }
   required_version = ">= 1.1.8"
 }

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -15,7 +15,7 @@ variable "domain_map" { type = map(any) }
 
 variable "ngwaf_site_name" { type = string }
 variable "ngwaf_email" { type = string }
-variable "ngwaf_token" { type = string , sensitive = true }
+variable "ngwaf_token" { type = string }
 variable "activate_ngwaf_service" { type = bool }
 variable "edge_security_dictionary" { type = string }
 

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -237,7 +237,7 @@ resource "fastly_service_vcl" "pypi" {
   dynamic "dictionary" {
     for_each = var.activate_ngwaf_service ? [1] : []
     content {
-      name = var.edge_security_dictionary
+      name          = var.edge_security_dictionary
       force_destroy = true
     }
   }

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -1,8 +1,8 @@
 provider "sigsci" {
   # if i dont add this it errors: Provider configuration not present
-  alias = "firewall"
-  corp = "python"
-  email = "infrastructure-staff@python.org"
+  alias      = "firewall"
+  corp       = "python"
+  email      = "infrastructure-staff@python.org"
   auth_token = var.ngwaf_token
 }
 

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -11,7 +11,7 @@ resource "fastly_service_dictionary_items" "edge_security_dictionary_items" {
   service_id    = fastly_service_vcl.pypi.id
   dictionary_id = one([for d in fastly_service_vcl.pypi.dictionary : d.dictionary_id if d.name == var.edge_security_dictionary])
   items = {
-    Enabled : "100"
+    Enabled : "50"
   }
 }
 

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -1,3 +1,9 @@
+provider "sigsci" {
+  # if i dont add this it errors: Provider configuration not present
+  alias = "firewall"
+  corp = "python"
+  email = "infrastructure-staff@python.org"
+}
 
 resource "fastly_service_dictionary_items" "edge_security_dictionary_items" {
   count         = var.activate_ngwaf_service ? 1 : 0

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -3,6 +3,7 @@ provider "sigsci" {
   alias = "firewall"
   corp = "python"
   email = "infrastructure-staff@python.org"
+  auth_token = var.ngwaf_token
 }
 
 resource "fastly_service_dictionary_items" "edge_security_dictionary_items" {

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -1,0 +1,50 @@
+
+resource "fastly_service_dictionary_items" "edge_security_dictionary_items" {
+  count         = var.activate_ngwaf_service ? 1 : 0
+  service_id    = fastly_service_vcl.pypi.id
+  dictionary_id = one([for d in fastly_service_vcl.pypi.dictionary : d.dictionary_id if d.name == var.edge_security_dictionary])
+  items = {
+    Enabled : "100"
+  }
+}
+
+resource "fastly_service_dynamic_snippet_content" "ngwaf_config_snippets" {
+  for_each        = var.activate_ngwaf_service ? toset(["init", "miss", "pass", "deliver"]) : []
+  service_id      = fastly_service_vcl.pypi.id
+  snippet_id      = one([for d in fastly_service_vcl.pypi.dynamicsnippet : d.snippet_id if d.name == "ngwaf_config_${each.key}"])
+  content         = "### Terraform managed ngwaf_config_${each.key}"
+  manage_snippets = false
+}
+
+# NGWAF Edge Deployment on SignalSciences.net
+resource "sigsci_edge_deployment" "ngwaf_edge_site_service" {
+  count           = var.activate_ngwaf_service ? 1 : 0
+  provider        = sigsci.firewall
+  site_short_name = var.ngwaf_site_name
+}
+
+resource "sigsci_edge_deployment_service" "ngwaf_edge_service_link" {
+  count            = var.activate_ngwaf_service ? 1 : 0
+  provider         = sigsci.firewall
+  site_short_name  = var.ngwaf_site_name
+  fastly_sid       = fastly_service_vcl.pypi.id
+  activate_version = var.activate_ngwaf_service
+  percent_enabled  = 100
+  depends_on = [
+    sigsci_edge_deployment.ngwaf_edge_site_service,
+    fastly_service_vcl.pypi,
+    fastly_service_dictionary_items.edge_security_dictionary_items,
+    fastly_service_dynamic_snippet_content.ngwaf_config_snippets,
+  ]
+}
+
+resource "sigsci_edge_deployment_service_backend" "ngwaf_edge_service_backend_sync" {
+  count                             = var.activate_ngwaf_service ? 1 : 0
+  provider                          = sigsci.firewall
+  site_short_name                   = var.ngwaf_site_name
+  fastly_sid                        = fastly_service_vcl.pypi.id
+  fastly_service_vcl_active_version = fastly_service_vcl.pypi.active_version
+  depends_on = [
+    sigsci_edge_deployment_service.ngwaf_edge_service_link,
+  ]
+}

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -2,7 +2,7 @@ provider "sigsci" {
   # if i dont add this it errors: Provider configuration not present
   alias      = "firewall"
   corp       = "python"
-  email      = "infrastructure-staff@python.org"
+  email      = var.ngwaf_email
   auth_token = var.ngwaf_token
 }
 

--- a/terraform/warehouse/versions.tf
+++ b/terraform/warehouse/versions.tf
@@ -6,6 +6,10 @@ terraform {
     fastly = {
       source = "fastly/fastly"
     }
+    sigsci = {
+      source  = "signalsciences/sigsci"
+      version = "3.3.0"
+    }
   }
   required_version = ">= 0.13"
 }

--- a/terraform/warehouse/versions.tf
+++ b/terraform/warehouse/versions.tf
@@ -5,6 +5,7 @@ terraform {
     }
     fastly = {
       source = "fastly/fastly"
+      version = ">= 5.13.0"
     }
     sigsci = {
       source  = "signalsciences/sigsci"

--- a/terraform/warehouse/versions.tf
+++ b/terraform/warehouse/versions.tf
@@ -4,7 +4,7 @@ terraform {
       source = "hashicorp/aws"
     }
     fastly = {
-      source = "fastly/fastly"
+      source  = "fastly/fastly"
       version = ">= 5.13.0"
     }
     sigsci = {


### PR DESCRIPTION
#### What

- Adds Fastlys NGWAF to PyPI on both environments, enabling only for test (which is even still in observe only mode)

The "observe" mode is done via SigSci UI at the moment for `pypi-test` site:
<img width="364" alt="image" src="https://github.com/user-attachments/assets/05e415f0-1577-48ee-972f-e56d07118a42">

