### PR TITLE
feat: enable pypi prod ngwaf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -114,9 +114,10 @@ module "pypi" {
   ngwaf_site_name          = "pypi-prod"
   ngwaf_email              = var.ngwaf_email
   ngwaf_token              = var.ngwaf_token
-  activate_ngwaf_service   = false
+  activate_ngwaf_service   = true
   edge_security_dictionary = "Edge_Security"
   fastly_key               = var.credentials["fastly"]
+  ngwaf_percent_enabled    = 10
 }
 
 module "test-pypi" {
@@ -152,6 +153,7 @@ module "test-pypi" {
   activate_ngwaf_service   = true
   edge_security_dictionary = "Edge_Security"
   fastly_key               = var.credentials["fastly"]
+  ngwaf_percent_enabled    = 100
 }
 
 module "file-hosting" {

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -19,6 +19,7 @@ variable "ngwaf_token" { type = string }
 variable "activate_ngwaf_service" { type = bool }
 variable "edge_security_dictionary" { type = string }
 variable "fastly_key" { type = string }
+variable "ngwaf_percent_enabled" { type = number }
 
 
 locals {

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -37,7 +37,7 @@ resource "sigsci_edge_deployment_service" "ngwaf_edge_service_link" {
   site_short_name  = var.ngwaf_site_name
   fastly_sid       = fastly_service_vcl.pypi.id
   activate_version = var.activate_ngwaf_service
-  percent_enabled  = 100
+  percent_enabled  = var.ngwaf_percent_enabled
   depends_on = [
     sigsci_edge_deployment.ngwaf_edge_site_service,
     fastly_service_vcl.pypi,


### PR DESCRIPTION
#### What

- Enables PyPI production ngwaf
- Adds var for percentage setting to [manage traffic flow](https://docs.fastly.com/en/ngwaf/edge-waf-deployment-using-the-next-gen-waf-control-panel#traffic-ramping)