### PR TITLE
chore: enable prod waf

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -114,7 +114,7 @@ module "pypi" {
   ngwaf_site_name          = "pypi-prod"
   ngwaf_email              = var.ngwaf_email
   ngwaf_token              = var.ngwaf_token
-  activate_ngwaf_service   = false
+  activate_ngwaf_service   = true
   edge_security_dictionary = "Edge_Security"
   fastly_key               = var.credentials["fastly"]
   ngwaf_percent_enabled    = 100


### PR DESCRIPTION
re-anables prod ngwaf at 100% as to not arbitrarily pick what traffic is inspected

still in non-blocking mode 