### PR TITLE
fix: explicitly manage ngwaf resources

### DIFF
--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -22,7 +22,7 @@ resource "fastly_service_dynamic_snippet_content" "ngwaf_config_snippets" {
   service_id      = fastly_service_vcl.pypi.id
   snippet_id      = one([for d in fastly_service_vcl.pypi.dynamicsnippet : d.snippet_id if d.name == "ngwaf_config_${each.key}"])
   content         = "### Terraform managed ngwaf_config_${each.key}"
-  manage_snippets = false
+  manage_snippets = true
 }
 
 # NGWAF Edge Deployment on SignalSciences.net

--- a/terraform/warehouse/ngwaf.tf
+++ b/terraform/warehouse/ngwaf.tf
@@ -14,6 +14,7 @@ resource "fastly_service_dictionary_items" "edge_security_dictionary_items" {
   items = {
     Enabled : "100"
   }
+  manage_items = true
 }
 
 resource "fastly_service_dynamic_snippet_content" "ngwaf_config_snippets" {


### PR DESCRIPTION
set `manage_items` to true to have hcl manage the fastly/ngwaf resources

Refs:
- https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_dictionary_items#reapplying-original-items-with-managed_items-if-the-state-of-the-items-drifts
- https://registry.terraform.io/providers/fastly/fastly/latest/docs/resources/service_dynamic_snippet_content#reapplying-original-snippets-with-manage_snippets-if-the-state-of-the-snippets-drifts