### PR TITLE
Prevent log churn 

### DIFF
--- a/terraform/file-hosting/fastly-service.tf
+++ b/terraform/file-hosting/fastly-service.tf
@@ -199,7 +199,7 @@ resource "fastly_service_vcl" "files" {
     url            = "https://toppops-ingest.fastlylabs.com/ingest"
     message_type   = "blank"
     format_version = 2
-    format         = ""
+    format         = "%h %l %u %t \"%r\" %>s %b" # %h %l %u %t "%r" %&gt;s %b
     content_type   = "text/plain"
     method         = "POST"
     placement      = "none"

--- a/terraform/inspector/main.tf
+++ b/terraform/inspector/main.tf
@@ -1,0 +1,60 @@
+variable "name" { type = string }
+variable "zone_id" { type = string }
+variable "domain" { type = string }
+variable "backend" { type = string }
+
+resource "fastly_service_vcl" "inspector" {
+  name     = var.name
+  activate = true
+
+  domain {
+    name = var.domain
+  }
+
+  backend {
+    name             = "PyPI Inspector"
+    shield           = "iad-va-us"
+    auto_loadbalance = true
+
+    healthcheck = "Inspector Health"
+
+    address           = var.backend
+    port              = 443
+    use_ssl           = true
+    ssl_cert_hostname = var.backend
+    ssl_sni_hostname  = var.backend
+
+    connect_timeout       = 5000
+    first_byte_timeout    = 60000
+    between_bytes_timeout = 15000
+    error_threshold       = 5
+  }
+
+  healthcheck {
+    name = "Inspector Health"
+
+    host   = var.domain
+    method = "GET"
+    path   = "/_health"
+
+    check_interval = 15000
+    timeout        = 5000
+    threshold      = 3
+    initial        = 4
+    window         = 5
+  }
+
+  lifecycle {
+    ignore_changes = [
+      product_enablement,
+    ]
+  }
+}
+
+resource "aws_route53_record" "primary" {
+  zone_id = var.zone_id
+  name    = var.domain
+  type    = "CNAME"
+  ttl     = 3600
+  records = ["inspector.ingress.us-east-2.pypi.io"]
+}

--- a/terraform/inspector/versions.tf
+++ b/terraform/inspector/versions.tf
@@ -1,0 +1,13 @@
+# vrsions in rest of repo need upgraded first to use these version specifiers
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      # version = "6.5.0"
+    }
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+  # required_version = ">= 1.12.0"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,7 @@ locals {
     "test.pythonhosted.org"       = "python.map.fastly.net"
     "files.pythonhosted.org"      = "python.map.fastly.net"
     "test-files.pythonhosted.org" = "python.map.fastly.net"
+    "inspector.pypi.io"           = "python.map.fastly.net"
   }
 }
 
@@ -258,6 +259,15 @@ module "pypi-camo" {
   sitename        = "PyPI Camo"
   domain          = "pypi-camo.global.ssl.fastly.net"
   backend_address = "warehouse-camo.ingress.us-east-2.pypi.io"
+}
+
+module "inspector" {
+  source = "./inspector"
+
+  name    = "Inspector"
+  zone_id = module.dns.primary_zone_id
+  domain  = "inspector.pypi.io"
+  backend = "inspector.ingress.us-east-2.pypi.io"
 }
 
 output "nameservers" { value = module.dns.nameservers }

--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -189,7 +189,7 @@ resource "fastly_service_vcl" "pypi" {
     url            = "https://toppops-ingest.fastlylabs.com/ingest"
     message_type   = "blank"
     format_version = 2
-    format         = ""
+    format         = "%h %l %u %t \"%r\" %>s %b" # %h %l %u %t "%r" %&gt;s %b
     content_type   = "text/plain"
     method         = "POST"
     placement      = "none"


### PR DESCRIPTION
Attempts to prevent log churn by explicitly setting the log format (even though it is using the default)

https://github.com/fastly/terraform-provider-fastly/issues/798#issuecomment-2992976841

https://github.com/pypi/infra/pull/206#pullrequestreview-3053537164