### PR TITLE
log the AS name and number

### DIFF
--- a/terraform/warehouse/main.tf
+++ b/terraform/warehouse/main.tf
@@ -140,7 +140,7 @@ resource "fastly_service_vcl" "pypi" {
   logging_s3 {
     name = "S3 Logs"
 
-    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\""
+    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{req.url}V\" %%{req.proto}V %>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" \"%%{client.as.number}V\" \"%%{cstr_escape(client.as.name)}V\""
     format_version = 2
     gzip_level     = 9
 
@@ -154,7 +154,7 @@ resource "fastly_service_vcl" "pypi" {
   logging_s3 {
     name = "S3 Error Logs"
 
-    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{cstr_escape(req.url)}V\" %%{req.proto}V %>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" %D \"%%{fastly_info.state}V\" \"%%{req.restarts}V\" \"%%{req.backend}V\""
+    format         = "%h \"%%{now}V\" %l \"%%{req.request}V %%{cstr_escape(req.url)}V\" %%{req.proto}V %>s %%{resp.http.Content-Length}V %%{resp.http.age}V \"%%{resp.http.x-cache}V\" \"%%{resp.http.x-cache-hits}V\" \"%%{req.http.content-type}V\" \"%%{req.http.accept-language}V\" \"%%{cstr_escape(req.http.user-agent)}V\" %D \"%%{fastly_info.state}V\" \"%%{req.restarts}V\" \"%%{req.backend}V\" \"%%{client.as.number}V\" \"%%{cstr_escape(client.as.name)}V\""
     format_version = 2
     gzip_level     = 9
 


### PR DESCRIPTION
We currently only log IP but Fastly are able to determine at the edge in more detail who the IP belongs to.

Does not expose it to BQ, just internal raw logs

- https://www.fastly.com/documentation/reference/vcl/variables/client-connection/client-as-name/
- https://www.fastly.com/documentation/reference/vcl/variables/client-connection/client-as-number/