### PR TITLE
fix: fall back to the archive backend when b2 fails to respond

### DIFF
--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -562,6 +562,16 @@ sub vcl_error {
         if (stale.exists) {
             return(deliver_stale);
         }
+
+        # Fastly synthesizes a 503 without running vcl_fetch when a backend
+        # times out, refuses the connection, or fails TLS negotiation, so the
+        # 5xx restart in vcl_fetch never sees those failures. Restart here so
+        # that vcl_recv can send us to the archive backend.
+        if (req.restarts < 1
+                && (req.request == "GET" || req.request == "HEAD")
+                && req.url ~ "^/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/") {
+            restart;
+        }
     }
 
     # Handle our "error" conditions which are really just ways to set synthetic


### PR DESCRIPTION
The B2 -> S3 Archive failover was driven entirely by the 5xx restart in vcl_fetch, but vcl_fetch only runs when B2 actually answers. On a timeout, refused connection, or TLS failure, Fastly synthesizes a 503 and jumps straight to vcl_error, so the restart never fired. vcl_error only handled the stale case, and package files are immutable, so the 503 fell through to the client and the archive was never tried.

The B2 backend runs 2000ms connect and first byte timeouts, so "B2 got slow" was both the likeliest failure mode and the one with no fallback.

Restart from vcl_error instead, guarded on req.restarts since the fourth restart is itself a 503.