### PR TITLE
fix: exempt inverted ranges from segmented caching

### DIFF
--- a/terraform/file-hosting/vcl/files.vcl
+++ b/terraform/file-hosting/vcl/files.vcl
@@ -18,6 +18,14 @@ sub vcl_recv {
         if (req.http.Range && req.http.Range !~ "^bytes=[0-9]+-[0-9]*$") {
             set req.enable_segmented_caching = false;
         }
+        # Inverted ranges (start > end) are well-formed but unsatisfiable, and
+        # segmented caching answers them with a 501 too. Exempt them so the
+        # normal range handling can return a 416 instead.
+        if (req.http.Range ~ "^bytes=([0-9]+)-([0-9]+)$") {
+            if (std.atoi(re.group.1) > std.atoi(re.group.2)) {
+                set req.enable_segmented_caching = false;
+            }
+        }
     }
 
     # I'm not 100% sure on what this is exactly for, it was taken from the


### PR DESCRIPTION
Segmented caching answers a well-formed but unsatisfiable range like bytes=271204080-12914479 with a 501. Two broken parallel downloaders generated 41k of them in a day against a handful of large wheels, all pinning the range end at chunk size minus one instead of offset plus chunk size minus one.

Disable segmented caching when start > end so the normal range handling returns a 416 instead.